### PR TITLE
Fix mobile topbar nav wrapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -84,13 +84,20 @@ html, body {
 @media (max-width: 768px) {
   #topbar {
     grid-template-columns: 1fr auto;
-    grid-template-rows: 44px 36px;
+    grid-template-rows: 44px auto;
     padding: 0; gap: 0;
     position: sticky; top: 0;
   }
   #topbar .logo         { grid-column: 1; grid-row: 1; padding-left: 12px; }
   #topbar .topbar-right { grid-column: 2; grid-row: 1; padding-right: 12px; gap: 6px; }
-  #topbar nav           { grid-column: 1 / -1; grid-row: 2; border-top: 1px solid var(--border); padding: 0 4px; }
+  #topbar nav {
+    grid-column: 1 / -1;
+    grid-row: 2;
+    border-top: 1px solid var(--border);
+    padding: 4px;
+    flex-wrap: wrap;
+    row-gap: 4px;
+  }
 }
 
 #topbar .logo {


### PR DESCRIPTION
### Motivation
- On smartphones the top navigation could overflow on a single line and break the layout, so tabs like `Personnages / Chroniques / Documents / Cartes / Campagnes / Règles` must be allowed to wrap into multiple lines only on mobile.

### Description
- In the mobile media query (`@media (max-width: 768px)`) changed `grid-template-rows: 44px 36px` to `grid-template-rows: 44px auto` to let the navigation row grow dynamically.
- Updated `#topbar nav` inside the mobile media query to use `flex-wrap: wrap`, `row-gap: 4px` and adjusted `padding` so nav buttons can flow across multiple lines.
- The change is scoped to the existing mobile media query so desktop behavior is unchanged and only `styles.css` was modified.

### Testing
- Ran `git diff -- styles.css` and inspected the CSS diff to confirm only the mobile topbar rules were changed (succeeded).
- Ran `git status --short` to confirm the file was staged and modified (succeeded).
- Committed the change with `git commit -m "Fix mobile topbar nav wrapping"` to record the update (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8a850c27483228b1c831ab3538c04)