### PR TITLE
Fix Markdown image sizing and auto-convert `--` to em-dash

### DIFF
--- a/chronicles.css
+++ b/chronicles.css
@@ -305,6 +305,16 @@
   border-radius: 6px; padding: 14px; overflow-x: auto; margin-bottom: 16px;
 }
 .chr-reader-body pre code { background: none; padding: 0; }
+.chr-reader-body img {
+  display: block;
+  max-width: 100%;
+  width: 100%;
+  height: auto;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  margin: 16px 0;
+}
+
 .chr-empty-preview { color: var(--text3); font-style: italic; }
 
 /* ── Mobile tabs ── */

--- a/chronicles.js
+++ b/chronicles.js
@@ -527,12 +527,13 @@ function populateEntryEditor() {
 
 function updateEntryPreview() {
   entryState.title   = document.getElementById('entry-f-title').value;
-  entryState.content = document.getElementById('entry-f-content').value;
+  const contentEl = document.getElementById('entry-f-content');
+  entryState.content = normalizeMarkdownTextarea(contentEl);
   const preview = document.getElementById('entry-preview-content');
   const titleHtml = entryState.title
     ? `<h1 class="chr-reader-title">${esc(entryState.title)}</h1>` : '';
   const bodyHtml = entryState.content
-    ? marked.parse(entryState.content)
+    ? renderMarkdown(entryState.content)
     : `<p class="chr-empty-preview">${t('entry_preview_empty')}</p>`;
   preview.innerHTML = titleHtml + `<div class="chr-reader-body">${bodyHtml}</div>`;
 }
@@ -568,7 +569,7 @@ function openEntryReader(entryId) {
     </div>
     <h1 class="chr-reader-title">${esc(entry.title)}</h1>
     <div class="chr-reader-meta">${date}</div>
-    <div class="chr-reader-body">${entry.content ? marked.parse(entry.content) : ''}</div>
+    <div class="chr-reader-body">${entry.content ? renderMarkdown(entry.content) : ''}</div>
   `;
   showView('entry-reader');
   const chrShareCode = (chronicles[activeChrId] || followedChronicles[activeChrId])?.share_code;

--- a/documents.css
+++ b/documents.css
@@ -258,9 +258,15 @@
 
 /* Images inline Markdown */
 .doc-reader-body img {
-  max-width: 100%; border-radius: 6px;
-  border: 1px solid var(--border); margin: 16px 0;
-  cursor: zoom-in; transition: opacity 0.15s;
+  display: block;
+  max-width: 100%;
+  width: 100%;
+  height: auto;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  margin: 16px 0;
+  cursor: zoom-in;
+  transition: opacity 0.15s;
 }
 .doc-reader-body img:hover { opacity: 0.92; }
 

--- a/documents.js
+++ b/documents.js
@@ -389,7 +389,8 @@ function populateDocEditor() {
 
 function updateDocForm() {
   docState.title     = document.getElementById('doc-f-title').value;
-  docState.content   = document.getElementById('doc-f-content').value;
+  const contentEl = document.getElementById('doc-f-content');
+  docState.content   = normalizeMarkdownTextarea(contentEl);
   docState.is_public = document.getElementById('doc-f-public').checked;
   document.getElementById('doc-public-label').textContent =
     docState.is_public ? t('share_code_active_doc') : t('share_code_inactive_doc');
@@ -399,12 +400,13 @@ function updateDocForm() {
 
 function updateDocPreview() {
   docState.title   = document.getElementById('doc-f-title').value;
-  docState.content = document.getElementById('doc-f-content').value;
+  const contentEl = document.getElementById('doc-f-content');
+  docState.content = normalizeMarkdownTextarea(contentEl);
   const preview = document.getElementById('doc-preview-content');
   const titleHtml = docState.title
     ? `<h1 class="doc-reader-title">${esc(docState.title)}</h1>` : '';
   const bodyHtml = docState.content
-    ? marked.parse(docState.content)
+    ? renderMarkdown(docState.content)
     : `<p class="doc-empty-preview">${t('doc_preview_empty')}</p>`;
   preview.innerHTML = titleHtml + `<div class="doc-reader-body">${bodyHtml}</div>`;
 }
@@ -471,7 +473,7 @@ function openDocReader(id) {
 
   // ── Rendu du contenu Markdown dans un div temporaire ──
   const tempDiv = document.createElement('div');
-  tempDiv.innerHTML = d.content ? marked.parse(d.content) : '';
+  tempDiv.innerHTML = d.content ? renderMarkdown(d.content) : '';
 
   // ── Collecte les H1 et H2 pour l'index ────────────────
   const headings = [];

--- a/rulebook.css
+++ b/rulebook.css
@@ -532,7 +532,10 @@
 
 /* Images */
 .rulebook-body img {
+  display: block;
   max-width: 100%;
+  width: 100%;
+  height: auto;
   border-radius: 6px;
   border: 1px solid var(--border);
   margin: 16px 0;

--- a/rulebook.js
+++ b/rulebook.js
@@ -51,7 +51,7 @@ async function loadRulebook() {
 
 function renderRulebook(markdown, contentEl, tocEl) {
   // ── 1. Parse le Markdown avec marked ─────────────────────────
-  const html = marked.parse(markdown);
+  const html = renderMarkdown(markdown);
 
   // ── 2. Inject dans un conteneur temporaire ────────────────────
   const tmp = document.createElement('div');

--- a/scripts.js
+++ b/scripts.js
@@ -643,6 +643,30 @@ function esc(s) {
     .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
 }
 
+
+function normalizeMarkdownTypography(text) {
+  if (!text) return '';
+  return String(text).replace(/(^|[\s\(\[{"'])--(?=\s|$|[\)\]}",.!?:;])/g, '$1—');
+}
+
+function normalizeMarkdownTextarea(textarea) {
+  if (!textarea) return '';
+  const start = textarea.selectionStart;
+  const end = textarea.selectionEnd;
+  const normalized = normalizeMarkdownTypography(textarea.value);
+  if (normalized !== textarea.value) {
+    textarea.value = normalized;
+    const nextStart = Math.max(0, start - 1);
+    const nextEnd = Math.max(0, end - 1);
+    textarea.setSelectionRange(nextStart, nextEnd);
+  }
+  return textarea.value;
+}
+
+function renderMarkdown(md) {
+  return marked.parse(normalizeMarkdownTypography(md || ''));
+}
+
 function pipRow(val, cls, max) {
   return Array.from({ length: max }, (_, i) =>
     `<div class="pip ${i < val ? cls : 'empty'}"></div>`


### PR DESCRIPTION
### Motivation
- Markdown images were rendered at full size instead of fitting the text column, causing layout issues in chronicles, documents and the rulebook. 
- Typographic consistency: convert typed `--` into an em dash (`—`) while editing and when rendering Markdown.

### Description
- Added shared Markdown helpers in `scripts.js`: `normalizeMarkdownTypography`, `normalizeMarkdownTextarea`, and `renderMarkdown` to centralize typography normalization and rendering. 
- Integrated textarea normalization into editors by using `normalizeMarkdownTextarea` for `entry` and `document` textareas so `--` is converted during typing. 
- Replaced direct `marked.parse(...)` calls with `renderMarkdown(...)` in `chronicles.js`, `documents.js`, and `rulebook.js` to apply the same normalization at render time. 
- Updated CSS in `chronicles.css`, `documents.css`, and `rulebook.css` to constrain Markdown inline images to the text column using `display: block; max-width: 100%; width: 100%; height: auto;` so images no longer overflow the content area.

### Testing
- Ran syntax/type checks: `node --check scripts.js`, `node --check chronicles.js`, `node --check documents.js`, and `node --check rulebook.js`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8bd1e1e148322b72316536db31b06)