### PR TITLE
Add persistent read/unread markers for followed content (DB + UI)

### DIFF
--- a/chronicles.css
+++ b/chronicles.css
@@ -133,6 +133,7 @@
   background: var(--bg2); border: 1px solid var(--border);
   border-radius: 6px; padding: 14px 16px;
   cursor: pointer; transition: all 0.15s;
+  position: relative;
 }
 .entry-row:hover { border-color: var(--border2); transform: translateX(3px); }
 .entry-row-header {

--- a/chronicles.js
+++ b/chronicles.js
@@ -74,11 +74,15 @@ async function loadFollowedChroniclesFromDB() {
   if (ids.length) {
     const { data: entries } = await sb
       .from('chronicle_entries')
-      .select('chronicle_id')
+      .select('id, chronicle_id')
       .in('chronicle_id', ids);
+    const entryIdsByChronicle = {};
     (entries || []).forEach(e => {
       countMap[e.chronicle_id] = (countMap[e.chronicle_id] || 0) + 1;
+      if (!entryIdsByChronicle[e.chronicle_id]) entryIdsByChronicle[e.chronicle_id] = [];
+      entryIdsByChronicle[e.chronicle_id].push(e.id);
     });
+    ids.forEach(id => unreadMarkers.syncChronicleEntries(id, entryIdsByChronicle[id] || []));
   }
 
   followedChronicles = {};
@@ -99,6 +103,7 @@ async function loadEntriesForChronicle(chrId) {
     .order('created_at', { ascending: false });
   if (error) { console.error('Erreur chargement entrées:', error); return; }
   chrEntries[chrId] = data || [];
+  unreadMarkers.syncChronicleEntries(chrId, chrEntries[chrId].map(e => e.id));
 }
 
 // ══════════════════════════════════════════════════════════════
@@ -272,6 +277,7 @@ function renderChroniclesList() {
     ...ownKeys.map(id    => chrCardHTML(id, chronicles[id], false)),
     ...followedKeys.map(id => chrCardHTML(id, followedChronicles[id], true)),
   ].join('');
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
 }
 
 function chrEntryCountLabel(n) {
@@ -297,7 +303,10 @@ function chrCardHTML(id, c, isFollowed) {
     </div>`;
 
   if (isFollowed) {
-    return `<div class="chr-card" onclick="showChrDetail('${id}')">
+    const entryIds = (chrEntries[id] || []).map(e => e.id);
+    const hasUnreadEntry = unreadMarkers.chronicleHasUnreadEntries(id, entryIds, false);
+    const showUnread = unreadMarkers.isChronicleUnread(id, false) || hasUnreadEntry;
+    return `<div class="chr-card" onclick="showChrDetail('${id}')">${unreadMarkers.cardDotHTML(showUnread)}
       ${c.illustration_url ? `<img class="card-illus" src="${esc(c.illustration_url)}" style="object-position:center ${c.illustration_position||0}%" onclick="event.stopPropagation();openLightbox('${esc(c.illustration_url)}')" alt="">` : ''}
       <div class="chr-card-actions">
         <button class="icon-btn danger" onclick="event.stopPropagation();unfollowChronicle('${id}')" title="${t('btn_unsubscribe')}">
@@ -346,6 +355,8 @@ async function showChrDetail(chrId) {
   await loadEntriesForChronicle(chrId);
   renderChrDetail();
   showView('chr-detail');
+  if (!chronicles[chrId]) unreadMarkers.markChronicleRead(chrId);
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
   const chr = chronicles[chrId] || followedChronicles[chrId];
   if (chr?.share_code) setHash('chr', chr.share_code);
 }
@@ -363,7 +374,7 @@ function renderChrDetail() {
     ? `<span class="chr-detail-owner">${t('chr_followed_owner')}${esc(chr._owner_name)}</span>` : '';
 
   const entriesHtml = entries.length
-    ? entries.map(e => entryRowHTML(e, isOwn)).join('')
+    ? entries.map(e => entryRowHTML(e, isOwn, activeChrId)).join('')
     : `<div class="chr-no-entries">${t('chr_no_entries')}</div>`;
 
   document.getElementById('chr-detail-content').innerHTML = `
@@ -391,13 +402,14 @@ function renderChrDetail() {
   `;
 }
 
-function entryRowHTML(e, isOwn) {
+function entryRowHTML(e, isOwn, chrId) {
   const date = e.created_at
     ? new Date(e.created_at).toLocaleDateString(currentLang === 'en' ? 'en-GB' : 'fr-FR', { day:'numeric', month:'long', year:'numeric' })
     : '';
   const preview = (e.content || '').replace(/#+\s*/g,'').replace(/\*+/g,'').replace(/\n/g,' ').slice(0, 160);
 
-  return `<div class="entry-row" onclick="openEntryReader('${e.id}')">
+  const unreadDot = unreadMarkers.entryDotHTML(unreadMarkers.isEntryUnread(chrId, e.id, isOwn));
+  return `<div class="entry-row" onclick="openEntryReader('${e.id}')">${unreadDot}
     <div class="entry-row-header">
       <div class="entry-row-title">${esc(e.title)}</div>
       <div class="entry-row-date">${date}</div>
@@ -572,6 +584,8 @@ function openEntryReader(entryId) {
     <div class="chr-reader-body">${entry.content ? renderMarkdown(entry.content) : ''}</div>
   `;
   showView('entry-reader');
+  if (!chronicles[activeChrId]) unreadMarkers.markEntryRead(activeChrId, entryId);
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
   const chrShareCode = (chronicles[activeChrId] || followedChronicles[activeChrId])?.share_code;
   if (chrShareCode) setHash('entry', chrShareCode, entryId);
 }

--- a/documents.js
+++ b/documents.js
@@ -246,6 +246,7 @@ function renderDocumentsList() {
     ...ownKeys.map(id    => docCardHTML(id, documents[id], false)),
     ...followedKeys.map(id => docCardHTML(id, followedDocuments[id], true)),
   ].join('');
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
 }
 
 function renderDocFilters() {
@@ -297,11 +298,12 @@ function docCardHTML(id, d, isFollowed) {
     : '';
 
   if (isFollowed) {
+    const unreadDot = unreadMarkers.cardDotHTML(unreadMarkers.isDocumentUnread(id, false));
     const cardTags = (followedDocTagMap[id]||[]).map(tid => {
       const tg = allDocTags.find(x => x.id === tid);
       return tg ? `<span class="tag-chip" style="background:${tg.color}22;color:${tg.color};border:1px solid ${tg.color}44">${esc(tg.name)}</span>` : '';
     }).join('');
-    return `<div class="doc-card" onclick="openDocReader('${id}')">
+    return `<div class="doc-card" onclick="openDocReader('${id}')">${unreadDot}
       ${d.illustration_url ? `<img class="card-illus" src="${esc(d.illustration_url)}" style="object-position:center ${d.illustration_position||0}%" onclick="event.stopPropagation();openLightbox('${esc(d.illustration_url)}')" alt="">` : ''}
       <div class="doc-card-actions">
         <button class="icon-btn" onclick="event.stopPropagation();editFollowedDocTags('${id}')" title="${t('card_manage_tags')}">
@@ -470,6 +472,7 @@ function openDocReader(id) {
   const d = followedDocuments[id] || documents[id];
   if (!d) return;
   const isOwn = !!documents[id];
+  if (!isOwn) unreadMarkers.markDocumentRead(id);
 
   // ── Rendu du contenu Markdown dans un div temporaire ──
   const tempDiv = document.createElement('div');
@@ -551,6 +554,7 @@ function openDocReader(id) {
     : `<div id="doc-reader-content">${contentHtml}</div>`;
 
   showView('doc-reader');
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
   if (d.share_code) setHash('doc', d.share_code);
 
   // ── Scroll spy ────────────────────────────────────────

--- a/index.html
+++ b/index.html
@@ -1139,6 +1139,7 @@
 <script src="i18n.js"></script>
 <script src="supabase-client.js"></script>
 <script src="game-system.js"></script>
+<script src="unread-markers.js"></script>
 <script src="chronicles.js"></script>
 <script src="documents.js"></script>
 <script src="campaigns.js"></script>

--- a/scripts.js
+++ b/scripts.js
@@ -297,6 +297,7 @@ async function onSignedIn(user) {
   document.getElementById('auth-screen').classList.remove('active');
   document.getElementById('loading-overlay').classList.add('active');
   document.getElementById('app').style.display = 'flex';
+  await unreadMarkers.initFromDB(currentUser.id);
   await Promise.all([
     loadCharsFromDB(),
     loadChroniclesFromDB(),
@@ -318,6 +319,7 @@ async function onSignedIn(user) {
 
 function onSignedOut() {
   currentUser = null;
+  unreadMarkers.resetCache();
   chars = {};
   document.getElementById('loading-overlay').classList.remove('active');
   document.getElementById('auth-screen').classList.add('active');
@@ -414,6 +416,7 @@ function renderList() {
     ...keys.map(id         => cardHTML(id, chars[id], false)),
     ...followedKeys.map(id => cardHTML(id, followedChars[id], true)),
   ].join('');
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
 }
 
 function cardHTML(id, c, isFollowed = false) {
@@ -422,7 +425,8 @@ function cardHTML(id, c, isFollowed = false) {
   const cardTags = _buildTagChips(id, isFollowed ? followedTagMap : charTagMap);
 
   if (isFollowed) {
-    return `<div class="char-card" onclick="showSharedChar(followedChars['${id}'])">
+    const unreadDot = unreadMarkers.cardDotHTML(unreadMarkers.isCharacterUnread(id, false));
+    return `<div class="char-card" onclick="showSharedChar(followedChars['${id}'])">${unreadDot}
       ${c.illustration_url ? _cardIllus(c) : ''}
       <div class="card-actions">
         <button class="icon-btn" onclick="event.stopPropagation();editFollowedTags('${id}')"
@@ -506,6 +510,8 @@ function showSharedChar(data) {
     ${renderCharSheet(data)}
   `;
   showView('shared');
+  if (data?.id) unreadMarkers.markCharacterRead(data.id);
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
   currentSharedCharCode = data.share_code || null;
   if (data.share_code) setHash('char', data.share_code);
 }

--- a/sql/18_read_markers.sql
+++ b/sql/18_read_markers.sql
@@ -1,0 +1,39 @@
+-- ══════════════════════════════════════════════════════════════
+-- Camply — Read markers persistants (DB)
+-- Stocke l'état lu/non-lu par utilisateur pour contenus suivis.
+-- ══════════════════════════════════════════════════════════════
+
+CREATE TABLE IF NOT EXISTS public.read_markers (
+  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  content_type TEXT NOT NULL CHECK (content_type IN ('character', 'document', 'chronicle', 'chronicle_entry')),
+  content_id   UUID NOT NULL,
+  parent_id    UUID,
+  read_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, content_type, content_id)
+);
+
+CREATE INDEX IF NOT EXISTS read_markers_user_idx ON public.read_markers(user_id);
+CREATE INDEX IF NOT EXISTS read_markers_parent_idx ON public.read_markers(parent_id) WHERE parent_id IS NOT NULL;
+
+ALTER TABLE public.read_markers ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "read_markers_select_own" ON public.read_markers;
+CREATE POLICY "read_markers_select_own"
+  ON public.read_markers FOR SELECT
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "read_markers_insert_own" ON public.read_markers;
+CREATE POLICY "read_markers_insert_own"
+  ON public.read_markers FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "read_markers_update_own" ON public.read_markers;
+CREATE POLICY "read_markers_update_own"
+  ON public.read_markers FOR UPDATE
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS "read_markers_delete_own" ON public.read_markers;
+CREATE POLICY "read_markers_delete_own"
+  ON public.read_markers FOR DELETE
+  USING (auth.uid() = user_id);

--- a/styles.css
+++ b/styles.css
@@ -115,6 +115,23 @@ html, body {
 #topbar nav button:hover  { color: var(--text); background: var(--bg3); }
 #topbar nav button.active { color: var(--accent); background: var(--bg3); }
 
+#topbar nav button { position: relative; }
+.nav-unread-dot {
+  position: absolute; top: 6px; right: 6px;
+  width: 7px; height: 7px; border-radius: 999px;
+  background: var(--accent2); box-shadow: 0 0 0 2px var(--bg3);
+}
+
+.unread-dot {
+  position: absolute;
+  width: 10px; height: 10px; border-radius: 999px;
+  background: var(--accent2);
+  box-shadow: 0 0 0 2px var(--bg2);
+  z-index: 3;
+}
+.unread-dot-card { top: 10px; right: 10px; }
+.unread-dot-entry { top: 10px; right: 10px; }
+
 @media (max-width: 768px) {
   #topbar nav button { padding: 5px 9px; font-size: 12px; }
   #topbar .logo      { font-size: 14px; }

--- a/unread-markers.js
+++ b/unread-markers.js
@@ -1,0 +1,164 @@
+(function(){
+  const state = {
+    userId: null,
+    loaded: false,
+    characters: {},
+    documents: {},
+    chronicles: {},
+    chronicle_entries: {}
+  };
+
+  function resetLocalState() {
+    state.loaded = false;
+    state.characters = {};
+    state.documents = {};
+    state.chronicles = {};
+    state.chronicle_entries = {};
+  }
+
+  function ensureChronicleMap(chrId) {
+    if (!state.chronicle_entries[chrId]) state.chronicle_entries[chrId] = {};
+    return state.chronicle_entries[chrId];
+  }
+
+  async function initFromDB(userId) {
+    state.userId = userId || null;
+    resetLocalState();
+    if (!state.userId) return;
+
+    const { data, error } = await sb
+      .from('read_markers')
+      .select('content_type, content_id, parent_id')
+      .eq('user_id', state.userId);
+
+    if (error) {
+      console.error('Erreur chargement read_markers:', error);
+      return;
+    }
+
+    (data || []).forEach(row => {
+      if (row.content_type === 'character') {
+        state.characters[row.content_id] = true;
+      } else if (row.content_type === 'document') {
+        state.documents[row.content_id] = true;
+      } else if (row.content_type === 'chronicle') {
+        state.chronicles[row.content_id] = true;
+      } else if (row.content_type === 'chronicle_entry' && row.parent_id) {
+        ensureChronicleMap(row.parent_id)[row.content_id] = true;
+      }
+    });
+
+    state.loaded = true;
+  }
+
+  async function upsertReadMarker(contentType, contentId, parentId = null) {
+    if (!state.userId || !contentType || !contentId) return;
+    const { error } = await sb
+      .from('read_markers')
+      .upsert({
+        user_id: state.userId,
+        content_type: contentType,
+        content_id: contentId,
+        parent_id: parentId,
+        read_at: new Date().toISOString()
+      }, { onConflict: 'user_id,content_type,content_id' });
+
+    if (error) console.error('Erreur sauvegarde read_marker:', error);
+  }
+
+  function markRead(bucket, id, dbType, parentId = null) {
+    if (!id) return;
+    state[bucket][id] = true;
+    upsertReadMarker(dbType, id, parentId);
+  }
+
+  function isUnread(bucket, id, isOwn) {
+    if (isOwn || !id) return false;
+    return !state[bucket][id];
+  }
+
+  function markEntryRead(chrId, entryId) {
+    if (!chrId || !entryId) return;
+    ensureChronicleMap(chrId)[entryId] = true;
+    upsertReadMarker('chronicle_entry', entryId, chrId);
+  }
+
+  function isEntryUnread(chrId, entryId, isOwn) {
+    if (isOwn || !chrId || !entryId) return false;
+    return !ensureChronicleMap(chrId)[entryId];
+  }
+
+  function syncChronicleEntries(chrId, entryIds) {
+    if (!chrId || !Array.isArray(entryIds)) return;
+    const known = ensureChronicleMap(chrId);
+    const keep = new Set(entryIds);
+    Object.keys(known).forEach(id => {
+      if (!keep.has(id)) delete known[id];
+    });
+  }
+
+  function chronicleHasUnreadEntries(chrId, entryIds, isOwn) {
+    if (isOwn || !chrId || !Array.isArray(entryIds) || !entryIds.length) return false;
+    const readMap = ensureChronicleMap(chrId);
+    return entryIds.some(id => !readMap[id]);
+  }
+
+  function cardDotHTML(show) {
+    return show ? '<span class="unread-dot unread-dot-card" aria-hidden="true"></span>' : '';
+  }
+
+  function entryDotHTML(show) {
+    return show ? '<span class="unread-dot unread-dot-entry" aria-hidden="true"></span>' : '';
+  }
+
+  function setNavDot(navId, show) {
+    const btn = document.getElementById(navId);
+    if (!btn) return;
+    let dot = btn.querySelector('.nav-unread-dot');
+    if (show && !dot) {
+      dot = document.createElement('span');
+      dot.className = 'nav-unread-dot';
+      dot.setAttribute('aria-hidden', 'true');
+      btn.appendChild(dot);
+    }
+    if (!show && dot) dot.remove();
+  }
+
+  function refreshNavBadges(ctx = {}) {
+    const followedChars = ctx.followedChars || {};
+    const followedDocuments = ctx.followedDocuments || {};
+    const followedChronicles = ctx.followedChronicles || {};
+    const chrEntries = ctx.chrEntries || {};
+
+    const hasUnreadChars = Object.keys(followedChars).some(id => isUnread('characters', id, false));
+    const hasUnreadDocs = Object.keys(followedDocuments).some(id => isUnread('documents', id, false));
+
+    const hasUnreadChronicles = Object.keys(followedChronicles).some(chrId => {
+      if (isUnread('chronicles', chrId, false)) return true;
+      const entries = chrEntries[chrId] || [];
+      return chronicleHasUnreadEntries(chrId, entries.map(e => e.id), false);
+    });
+
+    setNavDot('nav-list', hasUnreadChars);
+    setNavDot('nav-documents', hasUnreadDocs);
+    setNavDot('nav-chronicles', hasUnreadChronicles);
+  }
+
+  window.unreadMarkers = {
+    initFromDB,
+    resetCache: resetLocalState,
+    isCharacterUnread: (id, isOwn) => isUnread('characters', id, isOwn),
+    markCharacterRead: (id) => markRead('characters', id, 'character'),
+    isDocumentUnread: (id, isOwn) => isUnread('documents', id, isOwn),
+    markDocumentRead: (id) => markRead('documents', id, 'document'),
+    isChronicleUnread: (id, isOwn) => isUnread('chronicles', id, isOwn),
+    markChronicleRead: (id) => markRead('chronicles', id, 'chronicle'),
+    isEntryUnread,
+    markEntryRead,
+    syncChronicleEntries,
+    chronicleHasUnreadEntries,
+    cardDotHTML,
+    entryDotHTML,
+    refreshNavBadges
+  };
+})();


### PR DESCRIPTION
### Motivation
- Track per-user read/unread state for followed characters, documents, chronicles and chronicle entries so the UI can surface unread indicators and persist read state.
- Show visual unread dots on cards and navigation and mark items read when opened to improve user awareness of new content.

### Description
- Add a new DB migration `sql/18_read_markers.sql` that creates a `read_markers` table with RLS policies to store per-user read timestamps for `character`, `document`, `chronicle` and `chronicle_entry` items.
- Introduce `unread-markers.js` which manages an in-memory cache loaded from the DB, provides `initFromDB`, `mark*Read`, `is*Unread`, `syncChronicleEntries` and `refreshNavBadges`, and upserts markers to the DB via Supabase.
- Integrate unread logic into the app by including the new script in `index.html`, initializing it on sign-in in `scripts.js`, resetting on sign-out, and calling marker APIs from `chronicles.js`, `documents.js`, and list renderers to show dots on cards, entries and nav buttons and to mark items read when opened.
- Add CSS rules in `styles.css` and a minor layout tweak in `chronicles.css` to display unread dots correctly on cards and entry rows.

### Testing
- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db8f9de7a48333a3db6d4704a46681)