### PR TITLE
Fix unread indicators for followed characters and top-nav badges

### DIFF
--- a/chronicles.js
+++ b/chronicles.js
@@ -271,13 +271,13 @@ function renderChroniclesList() {
 
   document.getElementById('chr-count-badge').textContent = total ? `(${total})` : '';
 
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
   if (!total) { grid.innerHTML = ''; empty.style.display = 'flex'; return; }
   empty.style.display = 'none';
   grid.innerHTML = [
     ...ownKeys.map(id    => chrCardHTML(id, chronicles[id], false)),
     ...followedKeys.map(id => chrCardHTML(id, followedChronicles[id], true)),
   ].join('');
-  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
 }
 
 function chrEntryCountLabel(n) {

--- a/documents.js
+++ b/documents.js
@@ -240,13 +240,13 @@ function renderDocumentsList() {
   const total = Object.keys(documents).length + Object.keys(followedDocuments).length;
   document.getElementById('doc-count-badge').textContent = total ? `(${total})` : '';
   const allKeys = [...ownKeys, ...followedKeys];
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
   if (!allKeys.length) { grid.innerHTML = ''; empty.style.display = 'flex'; return; }
   empty.style.display = 'none';
   grid.innerHTML = [
     ...ownKeys.map(id    => docCardHTML(id, documents[id], false)),
     ...followedKeys.map(id => docCardHTML(id, followedDocuments[id], true)),
   ].join('');
-  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
 }
 
 function renderDocFilters() {

--- a/scripts.js
+++ b/scripts.js
@@ -309,6 +309,7 @@ async function onSignedIn(user) {
       ? ensureMapLayersCacheLoaded()
       : Promise.resolve()),
   ]);
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
   document.getElementById('loading-overlay').classList.remove('active');
   isAppReady = true;
   if (!navigateFromHash()) {
@@ -410,13 +411,13 @@ function renderList() {
   const grid  = document.getElementById('char-grid');
   const empty = document.getElementById('empty-state');
   const allKeys = [...keys, ...followedKeys];
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
   if (!allKeys.length) { grid.innerHTML = ''; empty.style.display = 'flex'; return; }
   empty.style.display = 'none';
   grid.innerHTML = [
     ...keys.map(id         => cardHTML(id, chars[id], false)),
     ...followedKeys.map(id => cardHTML(id, followedChars[id], true)),
   ].join('');
-  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
 }
 
 function cardHTML(id, c, isFollowed = false) {
@@ -510,7 +511,8 @@ function showSharedChar(data) {
     ${renderCharSheet(data)}
   `;
   showView('shared');
-  if (data?.id) unreadMarkers.markCharacterRead(data.id);
+  const characterId = data?.id || data?._db_id;
+  if (characterId) unreadMarkers.markCharacterRead(characterId);
   unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
   currentSharedCharCode = data.share_code || null;
   if (data.share_code) setHash('char', data.share_code);


### PR DESCRIPTION
### Motivation
- Followed characters opened in the shared view were not marked as read because the code used an identifier that was sometimes missing for followed items, leaving them perpetually "unread".
- Top-bar unread badges were only refreshed when entering an item detail, and list views that were empty prevented badge rendering.
- The unread badge state should be correct immediately after sign-in once data has been loaded.

### Description
- Use the persisted identifier when marking a followed character read in `showSharedChar` by checking `data.id` or `data._db_id` before calling `unreadMarkers.markCharacterRead` (`scripts.js`).
- Move `unreadMarkers.refreshNavBadges(...)` earlier in list render functions so badges are refreshed even when the list is empty in `renderList` (`scripts.js`), `renderDocumentsList` (`documents.js`) and `renderChroniclesList` (`chronicles.js`).
- Trigger `unreadMarkers.refreshNavBadges(...)` after the initial data loads in `onSignedIn` so top-nav badges reflect the loaded state as soon as the app becomes ready (`scripts.js`).

### Testing
- Ran syntax checks: `node --check scripts.js`, `node --check documents.js`, and `node --check chronicles.js`, all succeeded.
- Confirmed modified files parse and no JS syntax errors were introduced by the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db94f4ead08333bed49694a735e445)