### PR TITLE
Fix unread nav dots disappearing in list view

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -391,6 +391,7 @@ function showView(view) {
   if (view === 'map') { clearHash(); initMap(); }
   if (view === 'rulebook') { clearHash(); loadRulebook(); }
   applyTranslations();
+  unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries });
 }
 
 // ══════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation
- The unread indicator dots in the top navigation could vanish when switching views because `applyTranslations()` updates DOM text and can remove the visual badges, so unread markers must be restored after translations to keep badges visible in list views for characters, chronicles and documents.

### Description
- Add a call to `unreadMarkers.refreshNavBadges({ followedChars, followedDocuments, followedChronicles, chrEntries })` immediately after `applyTranslations()` inside `showView()` in `scripts.js` to re-add nav unread dots after i18n DOM updates.

### Testing
- Ran `node --check scripts.js` and the check completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbb446317c83339aa2576a3db0e3dc)