### PR TITLE
Ajout d'un assistant d'installation in-app (vérifications Supabase & Discord)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,12 @@ In site.webmanifest:
 
 6. **Set a campaign map** (optional)
     Edit map-config.js and add your maps if you want to use them in the application. 
+
+## Installation assistant (in-app)
+
+When a cloned template is opened, Camply now runs an installation assistant before letting users into the app:
+
+- Checks Supabase connectivity.
+- Detects missing SQL schema and attempts an automatic install via RPC (if an SQL runner RPC exists).
+- Checks Discord auth provider availability.
+- Displays contextual help pages from `/install/*.md`.

--- a/index.html
+++ b/index.html
@@ -81,6 +81,23 @@
   </div>
 </div>
 
+<!-- Installation assistant -->
+<div id="install-screen">
+  <div class="install-box">
+    <div class="install-head">
+      <div class="install-logo">Camply <span>TTRPG</span></div>
+      <div id="install-status-badge" class="install-status-badge">Vérification…</div>
+    </div>
+    <h2 id="install-title">Assistant d'installation</h2>
+    <p id="install-subtitle">On vérifie la configuration de Supabase et Discord…</p>
+    <div class="install-actions">
+      <button id="install-retry-btn" class="btn-primary" onclick="retryInstallationChecks()">Réessayer</button>
+      <button id="install-open-sql-btn" class="btn-cancel" onclick="openFreshInstallSql()" style="display:none">Ouvrir le script SQL</button>
+    </div>
+    <article id="install-markdown" class="install-markdown">Chargement…</article>
+  </div>
+</div>
+
 <div id="app">
 
   <!-- Top bar -->
@@ -1146,6 +1163,7 @@
 
 <script src="i18n.js"></script>
 <script src="supabase-client.js"></script>
+<script src="install.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js"></script>
 <script src="game-system.js"></script>
 <script src="unread-markers.js"></script>

--- a/install.js
+++ b/install.js
@@ -1,0 +1,179 @@
+const installAssistant = (() => {
+  const mdRoot = 'install';
+  const screenEl = () => document.getElementById('install-screen');
+
+  const state = {
+    ok: false,
+    running: false,
+    details: null,
+  };
+
+  function getEl(id) {
+    return document.getElementById(id);
+  }
+
+  function setStatus(title, subtitle, badgeText = 'Vérification…') {
+    getEl('install-title').textContent = title;
+    getEl('install-subtitle').textContent = subtitle;
+    getEl('install-status-badge').textContent = badgeText;
+  }
+
+  async function renderMarkdown(path, fallbackHtml) {
+    const container = getEl('install-markdown');
+    try {
+      const res = await fetch(path, { cache: 'no-store' });
+      if (!res.ok) throw new Error('markdown fetch failed');
+      const md = await res.text();
+      container.innerHTML = marked.parse(md);
+    } catch {
+      container.innerHTML = fallbackHtml;
+    }
+  }
+
+  async function checkSupabaseConnectivity() {
+    try {
+      const { error } = await sb.from('profiles').select('id').limit(1);
+      if (!error) return { ok: true };
+      if (error.code === '42P01') return { ok: false, reason: 'missing_schema', error };
+      if ((error.message || '').toLowerCase().includes('relation') && (error.message || '').toLowerCase().includes('does not exist')) {
+        return { ok: false, reason: 'missing_schema', error };
+      }
+      return { ok: false, reason: 'connection', error };
+    } catch (error) {
+      return { ok: false, reason: 'connection', error };
+    }
+  }
+
+  async function tryAutoInstallSchema() {
+    try {
+      const sqlRes = await fetch('sql/00_fresh_install.sql', { cache: 'no-store' });
+      if (!sqlRes.ok) return { ok: false, reason: 'sql_fetch_failed' };
+      const sql = await sqlRes.text();
+
+      // Tentatives d'auto-install (si un RPC admin existe déjà côté projet).
+      const candidates = [
+        { fn: 'run_sql', args: { sql_query: sql } },
+        { fn: 'run_sql', args: { p_sql: sql } },
+        { fn: 'execute_sql', args: { sql_query: sql } },
+        { fn: 'execute_sql', args: { p_sql: sql } },
+      ];
+
+      for (const candidate of candidates) {
+        const { error } = await sb.rpc(candidate.fn, candidate.args);
+        if (!error) return { ok: true, mode: `rpc:${candidate.fn}` };
+      }
+
+      return { ok: false, reason: 'no_rpc_runner' };
+    } catch {
+      return { ok: false, reason: 'auto_install_failed' };
+    }
+  }
+
+  async function checkDiscordProvider() {
+    try {
+      const { error } = await sb.auth.signInWithOAuth({
+        provider: 'discord',
+        options: {
+          skipBrowserRedirect: true,
+          redirectTo: window.location.origin + window.location.pathname,
+        }
+      });
+      if (!error) return { ok: true };
+      return { ok: false, error };
+    } catch (error) {
+      return { ok: false, error };
+    }
+  }
+
+  function showInstallScreen() {
+    screenEl()?.classList.add('active');
+    getEl('auth-screen')?.classList.remove('active');
+    getEl('loading-overlay')?.classList.remove('active');
+    getEl('app').style.display = 'none';
+  }
+
+  function hideInstallScreen() {
+    screenEl()?.classList.remove('active');
+  }
+
+  async function runChecks() {
+    if (state.running) return state.ok;
+    state.running = true;
+
+    showInstallScreen();
+    getEl('install-retry-btn').disabled = true;
+    getEl('install-open-sql-btn').style.display = 'none';
+    setStatus('Assistant d\'installation', 'On vérifie la configuration de Supabase et Discord…', 'Vérification');
+    await renderMarkdown(`${mdRoot}/install-schema.md`, '<p>Vérification en cours…</p>');
+
+    const supabaseCheck = await checkSupabaseConnectivity();
+    if (!supabaseCheck.ok && supabaseCheck.reason === 'connection') {
+      state.ok = false;
+      state.details = { stage: 'supabase_connection', supabaseCheck };
+      setStatus('Connexion Supabase requise', 'Camply ne peut pas se connecter à Supabase.', 'Action requise');
+      await renderMarkdown(`${mdRoot}/install-supabase-connection.md`, '<p>Vérifie la configuration Supabase dans <code>supabase-client.js</code>.</p>');
+      getEl('install-retry-btn').disabled = false;
+      state.running = false;
+      return false;
+    }
+
+    if (!supabaseCheck.ok && supabaseCheck.reason === 'missing_schema') {
+      setStatus('Initialisation de la base', 'Structure SQL absente, tentative d\'installation automatique…', 'Installation');
+      const autoInstall = await tryAutoInstallSchema();
+      const afterInstall = autoInstall.ok ? await checkSupabaseConnectivity() : supabaseCheck;
+      if (!afterInstall.ok) {
+        state.ok = false;
+        state.details = { stage: 'schema', autoInstall, afterInstall };
+        setStatus('Base de données à initialiser', 'La structure SQL n\'a pas pu être installée automatiquement.', 'Action requise');
+        await renderMarkdown(`${mdRoot}/install-schema.md`, '<p>Exécute <code>sql/00_fresh_install.sql</code> dans Supabase SQL Editor puis réessaye.</p>');
+        getEl('install-open-sql-btn').style.display = 'inline-flex';
+        getEl('install-retry-btn').disabled = false;
+        state.running = false;
+        return false;
+      }
+    }
+
+    const discordCheck = await checkDiscordProvider();
+    if (!discordCheck.ok) {
+      state.ok = false;
+      state.details = { stage: 'discord', discordCheck };
+      setStatus('Configuration Discord requise', 'Le provider Discord semble non configuré côté Supabase.', 'Action requise');
+      await renderMarkdown(`${mdRoot}/install-discord.md`, '<p>Active le provider Discord dans Supabase Auth puis réessaye.</p>');
+      getEl('install-retry-btn').disabled = false;
+      state.running = false;
+      return false;
+    }
+
+    state.ok = true;
+    state.details = { stage: 'ok' };
+    hideInstallScreen();
+    state.running = false;
+    return true;
+  }
+
+  function canEnterApp() {
+    return state.ok;
+  }
+
+  async function retry() {
+    const ok = await runChecks();
+    if (ok && typeof window.bootCamplyApp === 'function') {
+      await window.bootCamplyApp();
+    }
+    return ok;
+  }
+
+  function openFreshInstallSql() {
+    window.open('sql/00_fresh_install.sql', '_blank', 'noopener,noreferrer');
+  }
+
+  return {
+    runChecks,
+    canEnterApp,
+    retry,
+    openFreshInstallSql,
+  };
+})();
+
+window.retryInstallationChecks = () => installAssistant.retry();
+window.openFreshInstallSql = () => installAssistant.openFreshInstallSql();

--- a/install/install-discord.md
+++ b/install/install-discord.md
@@ -1,0 +1,14 @@
+# Provider Discord non configuré
+
+Supabase est accessible, la base est prête, mais l'authentification Discord n'est pas active.
+
+## Étapes
+
+1. Crée une application Discord (Developer Portal).
+2. Récupère `Client ID` et `Client Secret`.
+3. Dans Supabase > **Authentication > Providers > Discord**, active le provider.
+4. Colle `Client ID` et `Client Secret`.
+5. Ajoute le callback Supabase dans Discord OAuth Redirects.
+6. Ajoute l'URL GitHub Pages dans Supabase > **Authentication > URL Configuration**.
+
+Ensuite clique sur **Réessayer**.

--- a/install/install-schema.md
+++ b/install/install-schema.md
@@ -1,0 +1,17 @@
+# Base de données non initialisée
+
+La connexion Supabase est correcte, mais la structure SQL de Camply est absente.
+
+## Ce que Camply tente de faire
+
+- Exécuter automatiquement `sql/00_fresh_install.sql`.
+- Refaire une vérification de la table `profiles`.
+
+## Si l'installation automatique échoue
+
+1. Ouvre **Supabase > SQL Editor**.
+2. Copie/colle le contenu de `sql/00_fresh_install.sql`.
+3. Exécute le script.
+4. Reviens dans l'app et clique sur **Réessayer**.
+
+Tu peux aussi cliquer sur **Ouvrir le script SQL** pour l'afficher dans l'onglet du dépôt.

--- a/install/install-supabase-connection.md
+++ b/install/install-supabase-connection.md
@@ -1,0 +1,12 @@
+# Connexion Supabase non disponible
+
+Camply n'arrive pas à communiquer avec Supabase.
+
+## Vérifications rapides
+
+1. Ouvre `supabase-client.js` et vérifie `SUPABASE_URL` et `SUPABASE_KEY`.
+2. Dans Supabase > **Settings > API**, copie la clé **publishable / anon** (pas la service role).
+3. Dans Supabase > **Authentication > URL Configuration**, ajoute l'URL GitHub Pages.
+4. Vérifie la console navigateur (F12) pour un message CORS / réseau.
+
+Ensuite, clique sur **Réessayer**.

--- a/scripts.js
+++ b/scripts.js
@@ -22,6 +22,10 @@ let filterFollowed   = false;
 // ══════════════════════════════════════════════════════════════
 
 async function doDiscordLogin() {
+  if (window.installAssistant && !installAssistant.canEnterApp()) {
+    await installAssistant.runChecks();
+    return;
+  }
   const btn   = document.getElementById('btn-discord');
   const errEl = document.getElementById('discord-error');
   errEl.classList.remove('show');
@@ -269,6 +273,10 @@ async function unfollowChar(charId) {
 // ══════════════════════════════════════════════════════════════
 
 async function init() {
+  if (window.installAssistant) {
+    const installationOk = await installAssistant.runChecks();
+    if (!installationOk) return;
+  }
   const safetyTimer = setTimeout(() => onSignedOut(), 5000);
   try {
     const { data: { session } } = await sb.auth.getSession();
@@ -865,4 +873,5 @@ async function cleanupOrphanTags(type) {
 
 // ── Boot ──────────────────────────────────────────────────────
 document.getElementById('app').style.display = 'none';
+window.bootCamplyApp = init;
 init();

--- a/styles.css
+++ b/styles.css
@@ -506,6 +506,19 @@ html, body {
 .auth-success      { background: rgba(68,170,119,0.10); border: 1px solid rgba(68,170,119,0.30); color: var(--mov); font-size: 12px; padding: 10px 12px; border-radius: 6px; margin-top: 12px; text-align: center; display: none; }
 .auth-success.show { display: block; }
 
+#install-screen { display: none; position: fixed; inset: 0; z-index: 350; background: var(--bg); align-items: center; justify-content: center; padding: 24px; }
+#install-screen.active { display: flex; }
+.install-box { width: min(900px, 100%); max-height: calc(100vh - 48px); background: var(--bg2); border: 1px solid var(--border); border-radius: 14px; padding: 24px; display: flex; flex-direction: column; gap: 12px; }
+.install-head { display: flex; justify-content: space-between; align-items: center; gap: 10px; }
+.install-logo { font-size: 18px; font-weight: 700; color: var(--text); }
+.install-logo span { color: var(--text3); font-weight: 500; }
+.install-status-badge { font-family: var(--font-mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text2); border: 1px solid var(--border2); border-radius: 999px; padding: 4px 10px; }
+.install-actions { display: flex; gap: 10px; flex-wrap: wrap; }
+.install-markdown { margin-top: 6px; padding: 16px; border: 1px solid var(--border); border-radius: 10px; background: var(--bg); overflow: auto; font-size: 14px; }
+.install-markdown h1, .install-markdown h2, .install-markdown h3 { margin: 0 0 10px; }
+.install-markdown p, .install-markdown ul, .install-markdown ol { margin: 0 0 10px; color: var(--text2); }
+.install-markdown code { background: var(--bg3); border: 1px solid var(--border); border-radius: 6px; padding: 1px 5px; }
+
 .user-menu-wrap   { position: relative; }
 .user-btn         { display: flex; align-items: center; gap: 8px; background: var(--bg3); border: 1px solid var(--border); color: var(--text2); font-size: 12px; font-weight: 500; padding: 6px 12px; border-radius: 6px; cursor: pointer; transition: all 0.15s; }
 .user-btn:hover   { border-color: var(--border2); color: var(--text); }


### PR DESCRIPTION
### Motivation
- Offrir un écran d’accueil d’installation pour les utilisateurs qui cloneraient le template et hébergeraient l’app sur GitHub Pages afin de guider la configuration nécessaire. 
- Détecter et résoudre automatiquement ou guidé les problèmes fréquents : connexion Supabase cassée, schéma SQL absent, et provider Discord non configuré.

### Description
- Ajout d’un overlay d’assistant dans `index.html` et du style correspondant dans `styles.css` avec rendu Markdown et boutons `Réessayer` / `Ouvrir le script SQL` pour l’aide contextuelle. 
- Nouvelle logique externalisée dans `install.js` qui effectue les étapes de vérification : `checkSupabaseConnectivity`, tentative d’installation automatique du schéma via RPCs candidats (`run_sql` / `execute_sql`), et `checkDiscordProvider` (utilise `skipBrowserRedirect`).
- Intégration dans le flux de démarrage et d’authentification via `scripts.js` : les checks sont lancés avant le bootstrap principal, `doDiscordLogin` est bloqué tant que l’installation n’est pas validée, et un point d’entrée `window.bootCamplyApp` permet de relancer le boot après correction. 
- Ajout de fichiers d’aide Markdown dans `/install` (`install-supabase-connection.md`, `install-schema.md`, `install-discord.md`) et mise à jour du `README.md` pour documenter l’assistant.

### Testing
- Exécution de `node --check install.js` et vérification de l’absence d’erreurs de syntaxe (succès). 
- Exécution de `node --check scripts.js` et vérification de l’absence d’erreurs de syntaxe (succès).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df8fca2c508323ac8e695b5f10c4ff)