### PR TITLE
Expose installAssistant on window to restore install-screen checks

### DIFF
--- a/install.js
+++ b/install.js
@@ -175,5 +175,6 @@ const installAssistant = (() => {
   };
 })();
 
+window.installAssistant = installAssistant;
 window.retryInstallationChecks = () => installAssistant.retry();
 window.openFreshInstallSql = () => installAssistant.openFreshInstallSql();


### PR DESCRIPTION
### Motivation
- `scripts.js` checks for `window.installAssistant` to decide whether to run the installation checks, but `installAssistant` was only a local `const`, so the install assistant detection was ignored and users could reach the login screen even with an invalid Supabase config.

### Description
- Exposed the assistant by adding `window.installAssistant = installAssistant;` in `install.js` so existing checks in `scripts.js` detect it and the app shows the installation/help screen when Supabase is misconfigured.

### Testing
- Ran JavaScript syntax checks with `node --check install.js` and `node --check scripts.js`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df939383f483238684d22873a66315)