### PR TITLE
Fix install diagnostics ordering during setup checks

### DIFF
--- a/install.js
+++ b/install.js
@@ -106,10 +106,25 @@ const installAssistant = (() => {
     setStatus('Installation Assistant', 'Checking the Supabase and Discord configuration…', 'Checking');
     await renderMarkdown(`${mdRoot}/install-schema.md`, '<p>Verification in progress…</p>');
 
-    const supabaseCheck = await checkSupabaseConnectivity();
-    if (!supabaseCheck.ok && supabaseCheck.reason === 'connection') {
+    const results = {
+      supabaseCheck: await checkSupabaseConnectivity(),
+      autoInstall: null,
+      afterInstall: null,
+      discordCheck: null,
+    };
+
+    if (!results.supabaseCheck.ok && results.supabaseCheck.reason === 'missing_schema') {
+      results.autoInstall = await tryAutoInstallSchema();
+      results.afterInstall = results.autoInstall.ok ? await checkSupabaseConnectivity() : results.supabaseCheck;
+    }
+
+    // L'auth Discord est toujours vérifiée, même si un autre test échoue,
+    // afin de garantir un diagnostic stable avant d'afficher l'erreur prioritaire.
+    results.discordCheck = await checkDiscordProvider();
+
+    if (!results.supabaseCheck.ok && results.supabaseCheck.reason === 'connection') {
       state.ok = false;
-      state.details = { stage: 'supabase_connection', supabaseCheck };
+      state.details = { stage: 'supabase_connection', ...results };
       setStatus('Supabase login required', 'Camply cannot connect to Supabase.', 'Action required');
       await renderMarkdown(`${mdRoot}/install-supabase-connection.md`, '<p>Check the Supabase configuration in <code>supabase-client.js</code>.</p>');
       getEl('install-retry-btn').disabled = false;
@@ -117,26 +132,20 @@ const installAssistant = (() => {
       return false;
     }
 
-    if (!supabaseCheck.ok && supabaseCheck.reason === 'missing_schema') {
-      setStatus('Database initialization', 'Missing SQL structure, attempted automatic installation…', 'Installation');
-      const autoInstall = await tryAutoInstallSchema();
-      const afterInstall = autoInstall.ok ? await checkSupabaseConnectivity() : supabaseCheck;
-      if (!afterInstall.ok) {
-        state.ok = false;
-        state.details = { stage: 'schema', autoInstall, afterInstall };
-        setStatus('Database to initialize', 'The SQL structure could not be installed automatically.', 'Action required');
-        await renderMarkdown(`${mdRoot}/install-schema.md`, '<p>Run the command <code>sql/00_fresh_install.sql</code> in Supabase SQL Editor and then try again.</p>');
-        getEl('install-open-sql-btn').style.display = 'inline-flex';
-        getEl('install-retry-btn').disabled = false;
-        state.running = false;
-        return false;
-      }
+    if (!results.supabaseCheck.ok && results.supabaseCheck.reason === 'missing_schema' && !results.afterInstall?.ok) {
+      state.ok = false;
+      state.details = { stage: 'schema', ...results };
+      setStatus('Database to initialize', 'The SQL structure could not be installed automatically.', 'Action required');
+      await renderMarkdown(`${mdRoot}/install-schema.md`, '<p>Run the command <code>sql/00_fresh_install.sql</code> in Supabase SQL Editor and then try again.</p>');
+      getEl('install-open-sql-btn').style.display = 'inline-flex';
+      getEl('install-retry-btn').disabled = false;
+      state.running = false;
+      return false;
     }
 
-    const discordCheck = await checkDiscordProvider();
-    if (!discordCheck.ok) {
+    if (!results.discordCheck.ok) {
       state.ok = false;
-      state.details = { stage: 'discord', discordCheck };
+      state.details = { stage: 'discord', ...results };
       setStatus('Discord configuration required.', 'The Discord provider appears to be unconfigured on Supabase\'s side.', 'Action required');
       await renderMarkdown(`${mdRoot}/install-discord.md`, '<p>Activate the Discord provider in Supabase Auth and then try again.</p>');
       getEl('install-retry-btn').disabled = false;


### PR DESCRIPTION
### Motivation
- The install checks reported failures as they occurred which caused error messages to overwrite each other instead of presenting a complete, deterministic diagnostic sequence.
- The expected error priority is: Supabase connection first, then SQL schema, and finally Discord provider, and all checks must finish to display the correct top-priority error.

### Description
- Refactored `runChecks` in `install.js` to collect results into a single `results` object before deciding which error to surface.
- Only attempt SQL auto-install when the Supabase check reports `missing_schema`, and re-check connectivity after an auto-install attempt to populate `results.afterInstall`.
- Always run the Discord provider check so diagnostics are stable and complete, then apply a deterministic priority when setting `state.details` and the UI status.
- Updated error payloads to include the consolidated `results` so troubleshooting information is preserved in `state.details`.

### Testing
- Ran `node --check install.js` to verify the file is syntactically valid and the check passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69df9e2c93bc83228fcc4de98c9f7fc1)