### PR TITLE
Prioritize Supabase connection errors before schema checks

### DIFF
--- a/install.js
+++ b/install.js
@@ -31,6 +31,17 @@ const installAssistant = (() => {
   }
 
   async function checkSupabaseConnectivity() {
+    const isPlaceholder = (value) => {
+      if (!value || typeof value !== 'string') return true;
+      const trimmed = value.trim();
+      if (!trimmed) return true;
+      return trimmed.includes('XXXXXXXX') || trimmed.includes('YOUR_') || trimmed.includes('example');
+    };
+
+    if (isPlaceholder(SUPABASE_URL) || isPlaceholder(SUPABASE_KEY)) {
+      return { ok: false, reason: 'connection_config' };
+    }
+
     try {
       const { error } = await sb.from('profiles').select('id').limit(1);
       if (!error) return { ok: true };
@@ -118,11 +129,7 @@ const installAssistant = (() => {
       results.afterInstall = results.autoInstall.ok ? await checkSupabaseConnectivity() : results.supabaseCheck;
     }
 
-    // L'auth Discord est toujours vérifiée, même si un autre test échoue,
-    // afin de garantir un diagnostic stable avant d'afficher l'erreur prioritaire.
-    results.discordCheck = await checkDiscordProvider();
-
-    if (!results.supabaseCheck.ok && results.supabaseCheck.reason === 'connection') {
+    if (!results.supabaseCheck.ok && ['connection', 'connection_config'].includes(results.supabaseCheck.reason)) {
       state.ok = false;
       state.details = { stage: 'supabase_connection', ...results };
       setStatus('Supabase login required', 'Camply cannot connect to Supabase.', 'Action required');
@@ -131,6 +138,9 @@ const installAssistant = (() => {
       state.running = false;
       return false;
     }
+
+    // L'auth Discord est vérifiée uniquement si la connexion Supabase est fonctionnelle.
+    results.discordCheck = await checkDiscordProvider();
 
     if (!results.supabaseCheck.ok && results.supabaseCheck.reason === 'missing_schema' && !results.afterInstall?.ok) {
       state.ok = false;


### PR DESCRIPTION
### Motivation
- When a fresh template is duplicated without Supabase configured, the installer showed the SQL initialization message first instead of the missing-connection guidance, which confuses users; the change ensures the connection error is reported as step 1.

### Description
- Add a placeholder detector for `SUPABASE_URL` and `SUPABASE_KEY` in `checkSupabaseConnectivity()` and return `{ ok: false, reason: 'connection_config' }` for unset/placeholder values.
- Treat `'connection_config'` the same as `'connection'` in `runChecks()` and immediately show the Supabase connection guidance (`install-supabase-connection.md`).
- Defer calling `checkDiscordProvider()` until after Supabase connectivity is confirmed to avoid delaying the primary connection error message.
- Adjusted `runChecks()` flow to prioritize connection errors before attempting schema auto-installation and discord checks.

### Testing
- Ran `node --check install.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa00f7d808322abd29753f9bc8126)