### PR TITLE
Skip installation assistant when profiles already exist

### DIFF
--- a/install.js
+++ b/install.js
@@ -55,6 +55,21 @@ const installAssistant = (() => {
     }
   }
 
+  async function checkExistingProfiles() {
+    try {
+      const { data, error } = await sb
+        .from('profiles')
+        .select('id')
+        .limit(1);
+
+      if (error) return { ok: false, hasProfiles: false, error };
+
+      return { ok: true, hasProfiles: Array.isArray(data) && data.length > 0 };
+    } catch (error) {
+      return { ok: false, hasProfiles: false, error };
+    }
+  }
+
   async function tryAutoInstallSchema() {
     try {
       const sqlRes = await fetch('sql/00_fresh_install.sql', { cache: 'no-store' });
@@ -111,18 +126,31 @@ const installAssistant = (() => {
     if (state.running) return state.ok;
     state.running = true;
 
+    const results = {
+      supabaseCheck: await checkSupabaseConnectivity(),
+      profilesCheck: null,
+      autoInstall: null,
+      afterInstall: null,
+      discordCheck: null,
+    };
+
+    if (results.supabaseCheck.ok) {
+      results.profilesCheck = await checkExistingProfiles();
+
+      if (results.profilesCheck.ok && results.profilesCheck.hasProfiles) {
+        state.ok = true;
+        state.details = { stage: 'existing_profiles', ...results };
+        hideInstallScreen();
+        state.running = false;
+        return true;
+      }
+    }
+
     showInstallScreen();
     getEl('install-retry-btn').disabled = true;
     getEl('install-open-sql-btn').style.display = 'none';
     setStatus('Installation Assistant', 'Checking the Supabase and Discord configuration…', 'Checking');
     await renderMarkdown(`${mdRoot}/install-schema.md`, '<p>Verification in progress…</p>');
-
-    const results = {
-      supabaseCheck: await checkSupabaseConnectivity(),
-      autoInstall: null,
-      afterInstall: null,
-      discordCheck: null,
-    };
 
     if (!results.supabaseCheck.ok && results.supabaseCheck.reason === 'missing_schema') {
       results.autoInstall = await tryAutoInstallSchema();


### PR DESCRIPTION
### Motivation
- Prevent the installation assistant from running on projects that already have at least one user in the `profiles` table so the app is not treated as uninitialized.

### Description
- Add a `checkExistingProfiles()` helper that queries `profiles` with `select('id').limit(1)` and returns `{ ok, hasProfiles }`.
- Update `runChecks()` to call `checkExistingProfiles()` after a successful Supabase connectivity check and short-circuit the install flow by setting `state.ok = true` when `hasProfiles` is true, while leaving the existing installation logic unchanged when no profiles exist.

### Testing
- Ran `node --check install.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfa8a5bf0c832f93ea60ec7480c948)