### PR TITLE
Fix installer Supabase schema detection on missing profiles table

### DIFF
--- a/install.js
+++ b/install.js
@@ -35,7 +35,16 @@ const installAssistant = (() => {
       if (!value || typeof value !== 'string') return true;
       const trimmed = value.trim();
       if (!trimmed) return true;
-      return trimmed.includes('XXXXXXXX') || trimmed.includes('YOUR_') || trimmed.includes('example');
+      return /X{4,}/i.test(trimmed) || trimmed.includes('YOUR_') || trimmed.includes('example');
+    };
+
+    const isMissingSchemaError = (error) => {
+      if (!error) return false;
+      const message = (error.message || '').toLowerCase();
+      return error.code === '42P01'
+        || error.code === 'PGRST205'
+        || (message.includes('relation') && message.includes('does not exist'))
+        || (message.includes('could not find') && message.includes('in the schema cache'));
     };
 
     if (isPlaceholder(SUPABASE_URL) || isPlaceholder(SUPABASE_KEY)) {
@@ -45,8 +54,7 @@ const installAssistant = (() => {
     try {
       const { error } = await sb.from('profiles').select('id').limit(1);
       if (!error) return { ok: true };
-      if (error.code === '42P01') return { ok: false, reason: 'missing_schema', error };
-      if ((error.message || '').toLowerCase().includes('relation') && (error.message || '').toLowerCase().includes('does not exist')) {
+      if (isMissingSchemaError(error)) {
         return { ok: false, reason: 'missing_schema', error };
       }
       return { ok: false, reason: 'connection', error };


### PR DESCRIPTION
### Motivation
- The installer misclassifies Supabase REST 404 responses for the `profiles` table as a connection error, sending users back to the Supabase-connection step instead of the schema-initialization step. 
- The goal is to treat PostgREST `PGRST205` (HTTP 404) and other schema-missing signals as `missing_schema` so the user is guided to initialize the DB structure.

### Description
- Added `isMissingSchemaError(error)` to centralize detection of schema-missing conditions, covering `42P01`, `PGRST205`, and common message patterns like "relation does not exist" and "could not find ... in the schema cache".
- Updated `checkSupabaseConnectivity()` to use `isMissingSchemaError` and return `reason: 'missing_schema'` for those cases instead of `connection`.
- Strengthened placeholder detection for Supabase keys/URL by using the regex `/X{4,}/i` to catch masked values such as `XXXXX` in addition to previous checks.

### Testing
- Ran a static syntax/type check with `node --check install.js`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0f604eb40832f941b2af26cda18a5)