### PR TITLE
Guard Discord login behind provider pre-check during installation

### DIFF
--- a/install.js
+++ b/install.js
@@ -78,8 +78,45 @@ const installAssistant = (() => {
     }
   }
 
-    async function checkDiscordProvider() {
+  function readDiscordProviderFlag(settings) {
+    if (!settings || typeof settings !== 'object') return null;
+
+    const candidates = [
+      settings.external?.discord?.enabled,
+      settings.external?.discord,
+      settings.providers?.discord?.enabled,
+      settings.external_discord_enabled,
+    ];
+
+    for (const value of candidates) {
+      if (typeof value === 'boolean') return value;
+    }
+
+    return null;
+  }
+
+  async function checkDiscordProvider() {
     try {
+      const settingsRes = await fetch(`${SUPABASE_URL}/auth/v1/settings`, {
+        headers: {
+          apikey: SUPABASE_KEY,
+          Authorization: `Bearer ${SUPABASE_KEY}`,
+        },
+      });
+
+      if (settingsRes.ok) {
+        const settings = await settingsRes.json();
+        const enabled = readDiscordProviderFlag(settings);
+        if (enabled === false) {
+          return {
+            ok: false,
+            error: { message: 'Unsupported provider: provider is not enabled' },
+            source: 'settings',
+          };
+        }
+        if (enabled === true) return { ok: true, source: 'settings' };
+      }
+
       const { error } = await sb.auth.signInWithOAuth({
         provider: 'discord',
         options: {
@@ -87,8 +124,8 @@ const installAssistant = (() => {
           redirectTo: window.location.origin + window.location.pathname,
         }
       });
-      if (!error) return { ok: true };
-      return { ok: false, error };
+      if (!error) return { ok: true, source: 'oauth_probe' };
+      return { ok: false, error, source: 'oauth_probe' };
     } catch (error) {
       return { ok: false, error };
     }

--- a/scripts.js
+++ b/scripts.js
@@ -22,9 +22,9 @@ let filterFollowed   = false;
 // ══════════════════════════════════════════════════════════════
 
 async function doDiscordLogin() {
-  if (window.installAssistant && !installAssistant.canEnterApp()) {
-    await installAssistant.runChecks();
-    return;
+  if (window.installAssistant) {
+    const installationOk = await installAssistant.runChecks();
+    if (!installationOk) return;
   }
   const btn   = document.getElementById('btn-discord');
   const errEl = document.getElementById('discord-error');


### PR DESCRIPTION
### Motivation
- Prevent users from being redirected to Discord OAuth during installation when the Supabase Discord provider is not enabled, avoiding the `Unsupported provider: provider is not enabled` error.
- Surface provider configuration issues earlier in the install UI so the user stays on the installation assistant flow instead of hitting the Discord login screen.

### Description
- Added `readDiscordProviderFlag` and updated `checkDiscordProvider` in `install.js` to query Supabase Auth settings at `GET /auth/v1/settings` using `SUPABASE_URL` and `SUPABASE_KEY`, and detect explicit Discord enable/disable flags before attempting OAuth.  
- Kept the previous OAuth probe (`sb.auth.signInWithOAuth` with `skipBrowserRedirect`) as a fallback when settings are unavailable or inconclusive, and return a `source` indicator for clarity.  
- Changed Discord login flow in `scripts.js` so `doDiscordLogin` always re-runs installation checks via `installAssistant.runChecks()` when the assistant exists and aborts the OAuth redirect if the checks fail.

### Testing
- Ran `node --check install.js` and the file passed the syntax check.  
- Ran `node --check scripts.js` and the file passed the syntax check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e132df4778832283ae27849b4d68ef)