### PR TITLE
Expose APP_CONFIG on globalThis to restore Discord admin map access

### DIFF
--- a/app-config.js
+++ b/app-config.js
@@ -10,3 +10,6 @@ const APP_CONFIG = {
   // Exemples: ['Onirim', 'MJ_Principal']
   adminDiscordUsers: ['onirim.bzh'],
 };
+
+// Rend la config accessible de façon explicite depuis tous les scripts.
+globalThis.APP_CONFIG = APP_CONFIG;


### PR DESCRIPTION
### Motivation
- The map admin check in `map.js` reads `globalThis.APP_CONFIG?.adminDiscordUsers`, so `APP_CONFIG` must be globally accessible; when it was only a local `const`, configured Discord admins (e.g. `onirim.bzh`) were not granted map-wide access.

### Description
- Make the config global by adding `globalThis.APP_CONFIG = APP_CONFIG;` to the end of `app-config.js` so `map.js` can read the `adminDiscordUsers` list.

### Testing
- Ran `node --check app-config.js && node --check map.js` and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e364ee25988322946fb35f7b1015e2)