### PR TITLE
Permettre aux admins de modifier les fiches partagées suivies

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -17,6 +17,35 @@ let followedIds      = [];
 let followedTagMap   = {};
 let filterFollowed   = false;
 
+function normalizeDiscordName(name) {
+  return (name || '')
+    .trim()
+    .replace(/^@+/, '')
+    .replace(/#\d+$/, '')
+    .toLowerCase();
+}
+
+function getCurrentDiscordNames() {
+  if (!currentUser) return [];
+  const meta = currentUser.user_metadata || {};
+  const displayedName = meta.full_name
+    || meta.name
+    || meta.username
+    || (currentUser.email ? currentUser.email.split('@')[0] : '');
+  return [displayedName]
+    .map(normalizeDiscordName)
+    .filter(Boolean);
+}
+
+function isAppAdmin() {
+  const admins = (globalThis.APP_CONFIG?.adminDiscordUsers || [])
+    .map(normalizeDiscordName)
+    .filter(Boolean);
+  if (!admins.length) return false;
+  const names = getCurrentDiscordNames();
+  return names.some(n => admins.includes(n));
+}
+
 // ══════════════════════════════════════════════════════════════
 // AUTH
 // ══════════════════════════════════════════════════════════════
@@ -105,8 +134,11 @@ async function loadCharsFromDB() {
 async function saveCharToDB() {
   if (!state.name.trim()) { alert(t('alert_char_no_name')); return; }
   setSaveIndicator('saving', t('save_saving'));
+  const isEditingFollowedChar = !!(editingId && followedChars[editingId] && isAppAdmin());
+  const ownerId = (editingId && (chars[editingId]?._owner_id || followedChars[editingId]?._owner_id))
+    || currentUser.id;
   const payload = {
-    user_id:   currentUser.id,
+    user_id:   ownerId,
     name:      state.name.trim(),
     rank:      state.rank,
     is_public: state.is_public || false,
@@ -125,9 +157,19 @@ async function saveCharToDB() {
   }
   editingId        = result.data.id;
   state.share_code = result.data.share_code;
-  await saveCharTagsToDB(editingId);
-  chars[editingId]    = { ...state, _db_id: editingId };
-  charTagMap[editingId] = (state.tags || []).map(tg => tg.id);
+  if (!isEditingFollowedChar) {
+    await saveCharTagsToDB(editingId);
+    chars[editingId] = { ...state, _db_id: editingId, _owner_id: ownerId };
+    charTagMap[editingId] = (state.tags || []).map(tg => tg.id);
+  } else if (followedChars[editingId]) {
+    followedChars[editingId] = {
+      ...followedChars[editingId],
+      ...state,
+      _db_id: editingId,
+      _owner_id: ownerId,
+      share_code: result.data.share_code,
+    };
+  }
   const scBox = document.getElementById('share-code-box');
   const scVal = document.getElementById('share-code-val');
   if (scBox && scVal && state.is_public && state.share_code) {
@@ -208,7 +250,7 @@ async function loadFollowedCharsFromDB() {
     followedChars[row.id] = {
       ...row.data, name: row.name, rank: row.rank,
       is_public: row.is_public, share_code: row.share_code, _db_id: row.id,
-      _followed: true, _owner_name: ownerMap[row.user_id] || '?',
+      _followed: true, _owner_name: ownerMap[row.user_id] || '?', _owner_id: row.user_id,
     };
   });
 }
@@ -441,10 +483,16 @@ function cardHTML(id, c, isFollowed = false) {
   const cardTags = _buildTagChips(id, isFollowed ? followedTagMap : charTagMap);
 
   if (isFollowed) {
+    const canAdminEdit = isAppAdmin();
     const unreadDot = unreadMarkers.cardDotHTML(unreadMarkers.isCharacterUnread(id, false));
-    return `<div class="char-card" onclick="showSharedChar(followedChars['${id}'])">${unreadDot}
+    return `<div class="char-card" onclick="${canAdminEdit ? `editSharedFollowedChar('${id}')` : `showSharedChar(followedChars['${id}'])`}">${unreadDot}
       ${c.illustration_url ? _cardIllus(c) : ''}
       <div class="card-actions">
+        ${canAdminEdit ? `
+        <button class="icon-btn" onclick="event.stopPropagation();editSharedFollowedChar('${id}')"
+          title="${t('btn_edit')}">
+          ${_editIcon()}
+        </button>` : ''}
         <button class="icon-btn" onclick="event.stopPropagation();editFollowedTags('${id}')"
           title="${t('card_manage_tags')}">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -483,6 +531,13 @@ function cardHTML(id, c, isFollowed = false) {
     ${cardTags ? `<div class="card-tags">${cardTags}</div>` : ''}
     ${visTag}
   </div>`;
+}
+
+function editSharedFollowedChar(id) {
+  if (!isAppAdmin()) { showSharedChar(followedChars[id]); return; }
+  const shared = followedChars[id];
+  if (!shared) return;
+  editChar(id, shared);
 }
 
 // Helpers HTML internes


### PR DESCRIPTION
### Motivation
- Les administrateurs listés dans `APP_CONFIG.adminDiscordUsers` doivent pouvoir éditer des fiches de personnages publiques partagées qu’ils suivent, pour faciliter la gestion sans transférer la propriété.

### Description
- Ajout de helpers d’administration dans `scripts.js` : `normalizeDiscordName`, `getCurrentDiscordNames` et `isAppAdmin` pour détecter les admins à partir de `APP_CONFIG.adminDiscordUsers`.
- Autorisation côté UI : les cartes de personnages suivis affichent pour les admins un bouton `Modifier` et un clic ouvre l’éditeur au lieu de la vue partagée (fonction `editSharedFollowedChar`).
- Sauvegarde adaptée dans `saveCharToDB` : détection du cas admin éditant une fiche suivie (`isEditingFollowedChar`), conservation de l’`owner_id` original dans le payload et mise à jour locale de `followedChars` au lieu de créer une nouvelle entrée propriétaire.
- Chargement des personnages suivis enrichi pour conserver `_owner_id` afin d’identifier correctement le propriétaire lors d’éditions administratives.

### Testing
- Exécuté `node --check scripts.js` et la vérification a réussi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7416a97d483228bf247393c37e111)