### PR TITLE
Allow followers to edit followed characters (DB policy + admin UI)

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -17,6 +17,35 @@ let followedIds      = [];
 let followedTagMap   = {};
 let filterFollowed   = false;
 
+function normalizeDiscordName(name) {
+  return (name || '')
+    .trim()
+    .replace(/^@+/, '')
+    .replace(/#\d+$/, '')
+    .toLowerCase();
+}
+
+function getCurrentDiscordNames() {
+  if (!currentUser) return [];
+  const meta = currentUser.user_metadata || {};
+  const displayedName = meta.full_name
+    || meta.name
+    || meta.username
+    || (currentUser.email ? currentUser.email.split('@')[0] : '');
+  return [displayedName]
+    .map(normalizeDiscordName)
+    .filter(Boolean);
+}
+
+function isAppAdmin() {
+  const admins = (globalThis.APP_CONFIG?.adminDiscordUsers || [])
+    .map(normalizeDiscordName)
+    .filter(Boolean);
+  if (!admins.length) return false;
+  const names = getCurrentDiscordNames();
+  return names.some(n => admins.includes(n));
+}
+
 // ══════════════════════════════════════════════════════════════
 // AUTH
 // ══════════════════════════════════════════════════════════════
@@ -105,8 +134,8 @@ async function loadCharsFromDB() {
 async function saveCharToDB() {
   if (!state.name.trim()) { alert(t('alert_char_no_name')); return; }
   setSaveIndicator('saving', t('save_saving'));
+  const isEditingFollowedChar = !!(editingId && followedChars[editingId] && isAppAdmin());
   const payload = {
-    user_id:   currentUser.id,
     name:      state.name.trim(),
     rank:      state.rank,
     is_public: state.is_public || false,
@@ -116,7 +145,7 @@ async function saveCharToDB() {
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(editingId);
   const result = isValidUUID
     ? await sb.from('characters').update(payload).eq('id', editingId).select('id, share_code').single()
-    : await sb.from('characters').insert(payload).select('id, share_code').single();
+    : await sb.from('characters').insert({ ...payload, user_id: currentUser.id }).select('id, share_code').single();
   if (!isValidUUID && editingId) editingId = null;
   if (result.error) {
     setSaveIndicator('error', t('save_error'));
@@ -125,9 +154,19 @@ async function saveCharToDB() {
   }
   editingId        = result.data.id;
   state.share_code = result.data.share_code;
-  await saveCharTagsToDB(editingId);
-  chars[editingId]    = { ...state, _db_id: editingId };
-  charTagMap[editingId] = (state.tags || []).map(tg => tg.id);
+  if (!isEditingFollowedChar) {
+    await saveCharTagsToDB(editingId);
+    chars[editingId] = { ...state, _db_id: editingId, _owner_id: currentUser.id };
+    charTagMap[editingId] = (state.tags || []).map(tg => tg.id);
+  } else if (followedChars[editingId]) {
+    followedChars[editingId] = {
+      ...followedChars[editingId],
+      ...state,
+      _db_id: editingId,
+      _owner_id: followedChars[editingId]._owner_id || null,
+      share_code: result.data.share_code,
+    };
+  }
   const scBox = document.getElementById('share-code-box');
   const scVal = document.getElementById('share-code-val');
   if (scBox && scVal && state.is_public && state.share_code) {
@@ -208,7 +247,7 @@ async function loadFollowedCharsFromDB() {
     followedChars[row.id] = {
       ...row.data, name: row.name, rank: row.rank,
       is_public: row.is_public, share_code: row.share_code, _db_id: row.id,
-      _followed: true, _owner_name: ownerMap[row.user_id] || '?',
+      _followed: true, _owner_name: ownerMap[row.user_id] || '?', _owner_id: row.user_id,
     };
   });
 }
@@ -441,10 +480,16 @@ function cardHTML(id, c, isFollowed = false) {
   const cardTags = _buildTagChips(id, isFollowed ? followedTagMap : charTagMap);
 
   if (isFollowed) {
+    const canAdminEdit = isAppAdmin();
     const unreadDot = unreadMarkers.cardDotHTML(unreadMarkers.isCharacterUnread(id, false));
-    return `<div class="char-card" onclick="showSharedChar(followedChars['${id}'])">${unreadDot}
+    return `<div class="char-card" onclick="${canAdminEdit ? `editSharedFollowedChar('${id}')` : `showSharedChar(followedChars['${id}'])`}">${unreadDot}
       ${c.illustration_url ? _cardIllus(c) : ''}
       <div class="card-actions">
+        ${canAdminEdit ? `
+        <button class="icon-btn" onclick="event.stopPropagation();editSharedFollowedChar('${id}')"
+          title="${t('btn_edit')}">
+          ${_editIcon()}
+        </button>` : ''}
         <button class="icon-btn" onclick="event.stopPropagation();editFollowedTags('${id}')"
           title="${t('card_manage_tags')}">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -483,6 +528,13 @@ function cardHTML(id, c, isFollowed = false) {
     ${cardTags ? `<div class="card-tags">${cardTags}</div>` : ''}
     ${visTag}
   </div>`;
+}
+
+function editSharedFollowedChar(id) {
+  if (!isAppAdmin()) { showSharedChar(followedChars[id]); return; }
+  const shared = followedChars[id];
+  if (!shared) return;
+  editChar(id, shared);
 }
 
 // Helpers HTML internes

--- a/sql/00_fresh_install.sql
+++ b/sql/00_fresh_install.sql
@@ -112,11 +112,22 @@ CREATE POLICY "characters_insert"
   ON public.characters FOR INSERT
   WITH CHECK (auth.uid() = user_id);
 
--- characters : modification uniquement de ses propres personnages
+-- characters : modification
+--   → propriétaire
+--   → ou utilisateur abonné au personnage via followed_characters
+--     (utilisé pour permettre l'édition depuis le système de partage)
 DROP POLICY IF EXISTS "characters_update" ON public.characters;
 CREATE POLICY "characters_update"
   ON public.characters FOR UPDATE
-  USING (auth.uid() = user_id);
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1
+      FROM public.followed_characters fc
+      WHERE fc.character_id = characters.id
+        AND fc.user_id = auth.uid()
+    )
+  );
 
 -- characters : suppression uniquement de ses propres personnages
 DROP POLICY IF EXISTS "characters_delete" ON public.characters;

--- a/sql/00_schema.sql
+++ b/sql/00_schema.sql
@@ -104,11 +104,22 @@ CREATE POLICY "characters_insert"
   ON public.characters FOR INSERT
   WITH CHECK (auth.uid() = user_id);
 
--- characters : modification uniquement de ses propres personnages
+-- characters : modification
+--   → propriétaire
+--   → ou utilisateur abonné au personnage via followed_characters
+--     (utilisé pour permettre l'édition depuis le système de partage)
 DROP POLICY IF EXISTS "characters_update" ON public.characters;
 CREATE POLICY "characters_update"
   ON public.characters FOR UPDATE
-  USING (auth.uid() = user_id);
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1
+      FROM public.followed_characters fc
+      WHERE fc.character_id = characters.id
+        AND fc.user_id = auth.uid()
+    )
+  );
 
 -- characters : suppression uniquement de ses propres personnages
 DROP POLICY IF EXISTS "characters_delete" ON public.characters;

--- a/sql/18_followed_characters_update_policy.sql
+++ b/sql/18_followed_characters_update_policy.sql
@@ -1,0 +1,25 @@
+-- ══════════════════════════════════════════════════════════════
+-- Migration 18 — Autoriser la mise à jour des personnages suivis
+-- ══════════════════════════════════════════════════════════════
+--
+-- Objectif :
+-- Permettre à un utilisateur qui suit un personnage (table
+-- followed_characters) de modifier ce personnage.
+--
+-- Note :
+-- Le front Camply limite cette possibilité aux admins déclarés dans
+-- APP_CONFIG.adminDiscordUsers, mais côté SQL la règle est basée sur
+-- l'abonnement pour rester vérifiable côté base.
+
+DROP POLICY IF EXISTS "characters_update" ON public.characters;
+CREATE POLICY "characters_update"
+  ON public.characters FOR UPDATE
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1
+      FROM public.followed_characters fc
+      WHERE fc.character_id = characters.id
+        AND fc.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
### Motivation
- Enable editing of characters by users who follow them so the app can support shared-edit workflows while keeping a UI guard for admins. 
- Add server-side policy to permit updates from followers so the permission change is enforceable at the database level.

### Description
- Add helper functions `normalizeDiscordName`, `getCurrentDiscordNames`, and `isAppAdmin` to determine admin users based on `APP_CONFIG.adminDiscordUsers` in `scripts.js`.
- Allow admin users to open an edit flow for followed characters by adding `editSharedFollowedChar`, making followed-card clicks conditionally call the edit flow, and showing an edit button when `isAppAdmin()` is true in `cardHTML` (in `scripts.js`).
- Modify `saveCharToDB` to insert `user_id` on new character creation and to handle saving edits to followed characters without clobbering owner metadata or tags for followed entries (update either `chars` or `followedChars` accordingly) in `scripts.js`.
- Update `loadFollowedCharsFromDB` to include `_owner_id` on followed character objects in `scripts.js`.
- Add/update Postgres row-level security policies in `sql/00_schema.sql` and `sql/00_fresh_install.sql` to allow `UPDATE` on `characters` when the requester is the owner or is listed in `followed_characters`, and add a migration file `sql/18_followed_characters_update_policy.sql` containing the same policy and explanatory comments.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7416a97d483228bf247393c37e111)