### PR TITLE
Add collaborative write access for shared documents

### DIFF
--- a/documents.js
+++ b/documents.js
@@ -7,6 +7,7 @@ let documents         = {};
 let followedDocuments = {};
 let followedDocIds    = [];
 let editingDocId      = null;
+let editingDocIsFollowed = false;
 let docState          = null;
 
 // ── État tags documents ───────────────────────────────────────
@@ -110,13 +111,15 @@ async function loadFollowedDocumentsFromDB() {
 async function saveDocumentToDB() {
   if (!docState.title.trim()) { alert(t('alert_doc_no_title')); return; }
   const payload = {
-    user_id:               currentUser.id,
     title:                 docState.title.trim(),
     content:               docState.content,
-    is_public:             docState.is_public || false,
     illustration_url:      docState.illustration_url || '',
     illustration_position: docState.illustration_position || 0,
   };
+  if (!editingDocIsFollowed) {
+    payload.user_id = currentUser.id;
+    payload.is_public = docState.is_public || false;
+  }
   const isUUID = editingDocId &&
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(editingDocId);
 
@@ -133,8 +136,13 @@ async function saveDocumentToDB() {
   editingDocId = result.data.id;
   docState.share_code = result.data.share_code;
   await saveDocTagsToDB(editingDocId);
-  documents[editingDocId] = { ...docState, id: editingDocId };
-  docTagMap[editingDocId] = (docState.tags || []).map(tg => tg.id);
+if (editingDocIsFollowed) {
+    followedDocuments[editingDocId] = { ...followedDocuments[editingDocId], ...docState, id: editingDocId };
+    followedDocTagMap[editingDocId] = (docState.tags || []).map(tg => tg.id);
+  } else {
+    documents[editingDocId] = { ...docState, id: editingDocId };
+    docTagMap[editingDocId] = (docState.tags || []).map(tg => tg.id);
+  }
   updateDocShareCodeBox();
   showToast(t('toast_doc_saved'));
 }
@@ -306,6 +314,9 @@ function docCardHTML(id, d, isFollowed) {
     return `<div class="doc-card" onclick="openDocReader('${id}')">${unreadDot}
       ${d.illustration_url ? `<img class="card-illus" src="${esc(d.illustration_url)}" style="object-position:center ${d.illustration_position||0}%" onclick="event.stopPropagation();openLightbox('${esc(d.illustration_url)}')" alt="">` : ''}
       <div class="doc-card-actions">
+        <button class="icon-btn" onclick="event.stopPropagation();openDocEditor('${id}')" title="${t('btn_edit')}">
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M11 2l3 3-9 9H2v-3z"/></svg>
+        </button>
         <button class="icon-btn" onclick="event.stopPropagation();editFollowedDocTags('${id}')" title="${t('card_manage_tags')}">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M1 4h14M1 8h10M1 12h6"/></svg>
         </button>
@@ -358,6 +369,7 @@ function docCardHTML(id, d, isFollowed) {
 
 function newDocument() {
   editingDocId = null;
+  editingDocIsFollowed = false;
   docState = { title:'', content:'', is_public:false, share_code:null,
                illustration_url:'', illustration_position:0, tags:[] };
   showView('doc-editor');
@@ -366,9 +378,12 @@ function newDocument() {
 
 function openDocEditor(id) {
   editingDocId = id;
-  docState = { ...documents[id], tags:[] };
-  if (editingDocId && docTagMap[editingDocId]) {
-    docState.tags = docTagMap[editingDocId]
+  editingDocIsFollowed = !!followedDocuments[id] && !documents[id];
+  const sourceDoc = documents[id] || followedDocuments[id];
+  docState = { ...sourceDoc, tags:[] };
+  const tagSource = editingDocIsFollowed ? followedDocTagMap : docTagMap;
+  if (editingDocId && tagSource[editingDocId]) {
+    docState.tags = tagSource[editingDocId]
       .map(tid => allDocTags.find(tg => tg.id === tid))
       .filter(Boolean);
   }
@@ -381,6 +396,7 @@ function populateDocEditor() {
   document.getElementById('doc-f-content').value = docState.content || '';
   const pub = document.getElementById('doc-f-public');
   pub.checked = docState.is_public || false;
+  pub.disabled = editingDocIsFollowed;
   document.getElementById('doc-public-label').textContent =
     pub.checked ? t('share_code_active_doc') : t('share_code_inactive_doc');
   setDocIllusPreview(docState.illustration_url || '', docState.illustration_position || 0);
@@ -393,7 +409,7 @@ function updateDocForm() {
   docState.title     = document.getElementById('doc-f-title').value;
   const contentEl = document.getElementById('doc-f-content');
   docState.content   = normalizeMarkdownTextarea(contentEl);
-  docState.is_public = document.getElementById('doc-f-public').checked;
+  if (!editingDocIsFollowed) docState.is_public = document.getElementById('doc-f-public').checked;
   document.getElementById('doc-public-label').textContent =
     docState.is_public ? t('share_code_active_doc') : t('share_code_inactive_doc');
   updateDocShareCodeBox();
@@ -432,6 +448,7 @@ function copyDocShareCode() {
 }
 
 function shareDocBtn() {
+  if (editingDocIsFollowed) { showToast(t('toast_no_permission')); return; }
   if (!docState?.is_public) { showToast(t('toast_chr_share_need_public')); return; }
   const code = docState?.share_code || (editingDocId && documents[editingDocId]?.share_code);
   if (!code) { showToast(t('toast_chr_share_need_save')); return; }
@@ -516,7 +533,7 @@ function openDocReader(id) {
         onclick="openLightbox('${esc(d.illustration_url)}')" alt="">` : '';
 
   // ── Bannière ───────────────────────────────────────────
-  const bannerHtml = isOwn
+  const bannerHtml = (isOwn || !!followedDocuments[id])
     ? `<div class="doc-reader-header">
         <button class="btn-cancel" onclick="openDocEditor('${id}')">
           <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" width="13" height="13"><path d="M11 2l3 3-9 9H2v-3z"/></svg>

--- a/i18n.js
+++ b/i18n.js
@@ -411,6 +411,7 @@ const TRANSLATIONS = {
     toast_doc_own:               'That\'s your own document!',
     toast_doc_already_followed:  'You\'re already subscribed to this document.',
     toast_doc_follow_error:      'Error while subscribing.',
+    toast_no_permission:        'Only the owner can perform this action.',
     toast_doc_subscribed:        'Subscribed to "${title}"!',
     toast_doc_unsubscribed:      'Subscription removed.',
     toast_tag_error:             'Error creating tag.',

--- a/sql/00_fresh_install.sql
+++ b/sql/00_fresh_install.sql
@@ -527,6 +527,27 @@ CREATE TABLE IF NOT EXISTS public.followed_documents (
 
 CREATE INDEX IF NOT EXISTS followed_documents_user_idx ON public.followed_documents(user_id);
 
+CREATE OR REPLACE FUNCTION public.guard_document_shared_update()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF auth.uid() IS DISTINCT FROM OLD.user_id THEN
+    NEW.user_id := OLD.user_id;
+    NEW.is_public := OLD.is_public;
+    NEW.share_code := OLD.share_code;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS guard_document_shared_update ON public.documents;
+CREATE TRIGGER guard_document_shared_update
+  BEFORE UPDATE ON public.documents
+  FOR EACH ROW
+  EXECUTE FUNCTION public.guard_document_shared_update();
+
 
 -- ── 3. RLS ────────────────────────────────────────────────────
 
@@ -547,7 +568,20 @@ CREATE POLICY "documents_insert" ON public.documents FOR INSERT
 
 DROP POLICY IF EXISTS "documents_update" ON public.documents;
 CREATE POLICY "documents_update" ON public.documents FOR UPDATE
-  USING (auth.uid() = user_id);
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.followed_documents fd
+      WHERE fd.document_id = id AND fd.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.followed_documents fd
+      WHERE fd.document_id = id AND fd.user_id = auth.uid()
+    )
+  );
 
 DROP POLICY IF EXISTS "documents_delete" ON public.documents;
 CREATE POLICY "documents_delete" ON public.documents FOR DELETE

--- a/sql/04_documents.sql
+++ b/sql/04_documents.sql
@@ -45,6 +45,27 @@ CREATE TABLE IF NOT EXISTS public.followed_documents (
 
 CREATE INDEX IF NOT EXISTS followed_documents_user_idx ON public.followed_documents(user_id);
 
+CREATE OR REPLACE FUNCTION public.guard_document_shared_update()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  IF auth.uid() IS DISTINCT FROM OLD.user_id THEN
+    NEW.user_id := OLD.user_id;
+    NEW.is_public := OLD.is_public;
+    NEW.share_code := OLD.share_code;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS guard_document_shared_update ON public.documents;
+CREATE TRIGGER guard_document_shared_update
+  BEFORE UPDATE ON public.documents
+  FOR EACH ROW
+  EXECUTE FUNCTION public.guard_document_shared_update();
+
 
 -- ── 3. RLS ────────────────────────────────────────────────────
 
@@ -65,7 +86,20 @@ CREATE POLICY "documents_insert" ON public.documents FOR INSERT
 
 DROP POLICY IF EXISTS "documents_update" ON public.documents;
 CREATE POLICY "documents_update" ON public.documents FOR UPDATE
-  USING (auth.uid() = user_id);
+  USING (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.followed_documents fd
+      WHERE fd.document_id = id AND fd.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    auth.uid() = user_id
+    OR EXISTS (
+      SELECT 1 FROM public.followed_documents fd
+      WHERE fd.document_id = id AND fd.user_id = auth.uid()
+    )
+  );
 
 DROP POLICY IF EXISTS "documents_delete" ON public.documents;
 CREATE POLICY "documents_delete" ON public.documents FOR DELETE


### PR DESCRIPTION
### Motivation
- Allow users who follow a public document to edit its editable content (title, body, illustration) while keeping ownership controls restricted to the original owner.
- Prevent followed-users from changing protected metadata (`user_id`, `is_public`, `share_code`) while enabling safe collaborative updates.

### Description
- Frontend: introduce `editingDocIsFollowed` and adapt the editor flow so that when editing a followed document the form disables the public toggle and the save payload omits `user_id` and `is_public`, updating the correct local store (`documents` vs `followedDocuments`).
- Frontend: add edit entry points for followed documents on document cards and from the reader banner so followers can open the editor for collaborative edits.
- Backend SQL: expand `documents_update` RLS policy to allow updates by the owner or any user with a `followed_documents` row, and add a `WITH CHECK` clause to mirror that condition.
- Backend SQL: add `guard_document_shared_update()` trigger to enforce that non-owners cannot modify protected fields (`user_id`, `is_public`, `share_code`) even when RLS allows updating the row content.
- i18n: add a `toast_no_permission` message and use it to inform followers attempting owner-only actions.
- Files changed: `documents.js`, `i18n.js`, `sql/04_documents.sql`, and `sql/00_fresh_install.sql`.

### Testing
- Ran `node --check documents.js` and it succeeded.
- Ran `node --check i18n.js` and it succeeded.
- Verified SQL additions are present in `sql/04_documents.sql` and `sql/00_fresh_install.sql` to support fresh installs and upgrades.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8031961cc8322a401e5aa6a13c2da)